### PR TITLE
Update README.Rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -27,8 +27,8 @@ You can install `ebirdst` from GitHub with:
 
 ```{r gh-installation, eval = FALSE}
 # install the development version from GitHub
-# install.packages("devtools")
-devtools::install_github("CornellLabofOrnithology/ebirdst")
+# install.packages("remotes")
+remotes::install_github("CornellLabofOrnithology/ebirdst")
 ```
 
 ## Vignettes


### PR DESCRIPTION
remotes::install_github()` is now preferred over `devtools::install_github()`, which now just calls the former. `remotes` was split out in to its own package to make it much lighter weight than devtools.